### PR TITLE
Hide signature fields for hardware wallets

### DIFF
--- a/src/components/PayoutConfig/components/BitcoinSettings/BitcoinSettings.tsx
+++ b/src/components/PayoutConfig/components/BitcoinSettings/BitcoinSettings.tsx
@@ -385,6 +385,7 @@ export const BitcoinSettings = ({
           },
           { shouldDirty: true }
         );
+        setValue("walletType", signatureData.walletType, { shouldDirty: true });
 
         setValue("depositAddress", signatureData.zPub, {
           shouldValidate: false
@@ -414,6 +415,7 @@ export const BitcoinSettings = ({
             },
             { shouldDirty: true }
           );
+          setValue("walletType", signatureData.walletType, { shouldDirty: true });
           toast.show(
             t("hardwareConnectSuccess", {
               hardwareWallet: hardwareNames[signatureData.walletType]


### PR DESCRIPTION
Set `walletType` in the form state for hardware and local 12-word wallets to correctly hide the "Sign this message" and "Your signature" fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-63981153-0ce2-4777-a3a5-abcc24dffcdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63981153-0ce2-4777-a3a5-abcc24dffcdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

