### PR TITLE
fix(android): drop AllowFileAccess + AllowUniversalAccessFromFileURLs on the BitBox bridge WebView

### DIFF
--- a/android/app/src/main/java/ch/swissbitcoinpay/checkout/BitBoxBridgeModule.java
+++ b/android/app/src/main/java/ch/swissbitcoinpay/checkout/BitBoxBridgeModule.java
@@ -194,8 +194,6 @@ public class BitBoxBridgeModule extends ReactContextBaseJavaModule implements Li
         vw.clearCache(true);
         vw.clearHistory();
         vw.getSettings().setJavaScriptEnabled(true);
-        vw.getSettings().setAllowUniversalAccessFromFileURLs(true);
-        vw.getSettings().setAllowFileAccess(true);
 
         var url = vw.getUrl();
 


### PR DESCRIPTION
Closes #362.

`BitBoxBridgeModule.startServer()` configures the hidden `sbp_bitbox_webview`:


`vw.getSettings().setJavaScriptEnabled(true);`
`vw.getSettings().setAllowUniversalAccessFromFileURLs(true);`
`vw.getSettings().setAllowFileAccess(true);`


The WebView is created from the React Native side as `<Webview androidWebviewId=\"sbp_bitbox_webview\" source={{ html: \"\" }} ... />`, so it is never on a `file://` origin. Both file-access flags only take effect once the WebView lands on a file scheme, so they do not change anything for the BitBox JS bridge handshake but they expand what a file URL page could read if the WebView ever ended up on one.

`setAllowUniversalAccessFromFileURLs(true)` in particular is the CWE-200 pattern called out in Android's WebSettings documentation: it lets a file URL page issue XHR against any other origin, including app-private files served by the WebView's data dir.

### Change

Delete the two `setAllow...` calls. Defaults are correct for what this WebView does. On API 30+ both default to false anyway. On older devices they default to true unless turned off explicitly, so the removal tightens posture on those devices while leaving modern behaviour unchanged.

`setJavaScriptEnabled(true)` and the bridge stay in place, since those are how the BitBox handshake actually works.